### PR TITLE
Arduino library name change to avdweb_Switch

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,4 @@
-name=Switch
+name=avdweb_Switch
 version=1.0.5
 author=Albert van Dalen
 maintainer=Albert van Dalen <a@maxun.cc>


### PR DESCRIPTION
Change the name which is used in the Arduino libraries. This way the arduino library name is consistent with the include directive (avdweb_Switch)