### PR TITLE
fix esp32 issue : https://github.com/avandalen/avdweb_Switch/issues/15

### DIFF
--- a/avdweb_Switch.h
+++ b/avdweb_Switch.h
@@ -47,8 +47,8 @@ public:
 
   unsigned long deglitchTime, switchedTime, pushedTime, releasedTime, ms;
   const byte pin;
-  const int deglitchPeriod, debouncePeriod, longPressPeriod, doubleClickPeriod;
   const bool polarity;
+  const int deglitchPeriod, debouncePeriod, longPressPeriod, doubleClickPeriod;
   bool input, lastInput, equal, deglitched, debounced, _switched, _longPress, longPressDisable, _doubleClick, _singleClick, singleClickDisable;
 
   // Event callbacks


### PR DESCRIPTION
please accept pull request for bug with ESP32 , and tag 1.2.2 to correct default usage.

BUG:

In file included from .pio/libdeps/esp32doit-devkit-v1/Switch/avdweb_Switch.cpp:111:0:
.pio/libdeps/esp32doit-devkit-v1/Switch/avdweb_Switch.h: In constructor 'Switch::Switch(byte, byte, bool, int, int, int, int)':
.pio/libdeps/esp32doit-devkit-v1/Switch/avdweb_Switch.h:50:14: error: 'Switch::polarity' will be initialized after [-Werror=reorder]
   const bool polarity;
